### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "ava"
   },
   "author": "Alex Puschinsky",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "ava": "^3.9.0",
     "sinon": "^9.0.2"


### PR DESCRIPTION
`LICENSE` in this repo has an MIT license but `package.json` lists the license as `ISC`, meaning https://npm.im/dotago says `ISC. This PR updates `package.json` to say `MIT`.